### PR TITLE
⬇️ Downgrades action-gh-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,7 +112,7 @@ jobs:
         path: ./out/
     - name: Publish GitHub release
       id: publish_github_release
-      uses: softprops/action-gh-release@v2.2.0
+      uses: softprops/action-gh-release@01570a1f39cb168c169c802c3bceb9e93fb10974 # v2.1.0
       with:
         token: "${{ secrets.RELEASE_GITHUB_TOKEN }}"
         name: "v${{ steps.gitversion_vars.outputs.SemVer }}"


### PR DESCRIPTION
Version 2.2 of action-gh-release contains a bug preventing upload of our NuGet artifacts.

For more information, see: https://github.com/softprops/action-gh-release/issues/555